### PR TITLE
fix: pin system time in collect test

### DIFF
--- a/test/lib/data/collect.test.ts
+++ b/test/lib/data/collect.test.ts
@@ -1,6 +1,7 @@
 import { collectPackageData } from '../../../src/library/data/collect';
 import { GitHubRepo } from '../../../src/library/data/github-repo';
 import { NpmCollector } from '../../../src/library/data/npm';
+import { pinSystemTime } from '../../util';
 
 // Mock the collectors
 jest.mock('../../../src/library/data/npm');
@@ -10,6 +11,10 @@ const MockedNpmCollector = NpmCollector as jest.MockedClass<typeof NpmCollector>
 const MockedGitHubRepo = GitHubRepo as jest.MockedClass<typeof GitHubRepo>;
 
 describe('collectPackageData', () => {
+  // Release signals count a trailing year from the current time, so pin the
+  // clock to keep the absolute dates below inside the window
+  pinSystemTime(new Date('2025-11-01T00:00:00Z'));
+
   const mockNpmData = {
     name: 'test-package',
     version: '1.0.0',

--- a/test/lib/utils/releases.test.ts
+++ b/test/lib/utils/releases.test.ts
@@ -1,17 +1,11 @@
 import type { GitHubRelease } from '../../../src/library/types';
 import { calculateReleaseFrequency } from '../../../src/library/utils/releases';
+import { pinSystemTime } from '../../util';
 
 describe('calculateReleaseFrequency', () => {
   const currentDate = new Date('2024-10-28T00:00:00Z');
 
-  beforeAll(() => {
-    jest.useFakeTimers();
-    jest.setSystemTime(currentDate);
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
+  pinSystemTime(currentDate);
 
   test('should return 0 when no releases are provided', () => {
     expect(calculateReleaseFrequency(undefined)).toBe(0);

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,13 @@
+/**
+ * Pin the system time for all tests in the enclosing describe block
+ */
+export function pinSystemTime(date: Date): void {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(date);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+}


### PR DESCRIPTION
The release-derived signals (`releaseFrequency`, `numberOfFeatsAndFixes`, `releaseNotesIncludeFeatsAndFixes`) count a trailing year from the current time. `collect.test.ts` feeds them mocked releases with fixed 2025 dates but never pins the clock, so the expected values decay as the dates age out of the window.

Pin the clock to 2025-11-01 with fake timers, extracted to a shared `pinSystemTime` helper that `releases.test.ts` (already pinned inline) uses too.